### PR TITLE
Implement hough circles

### DIFF
--- a/CV/Bindings/ImgProc.hsc
+++ b/CV/Bindings/ImgProc.hsc
@@ -119,6 +119,18 @@ copyMakeBorder i t b l r border value =
 --   double param1 CV_DEFAULT(0),
 --   double param2 CV_DEFAULT(0)
 -- );
+--
+-- CvSeq* cvHoughCircles(
+--   CvArr* image,
+--   void* circle_storage,
+--   int method,
+--   double dp,
+--   double min_dist,
+--   double param1=100,
+--   double param2=100,
+--   int min_radius=0,
+--   int max_radius=0
+-- );
 
 #num CV_HOUGH_STANDARD
 #num CV_HOUGH_PROBABILISTIC
@@ -126,6 +138,7 @@ copyMakeBorder i t b l r border value =
 #num CV_HOUGH_GRADIENT
 
 #ccall cvHoughLines2, Ptr <CvArr> -> Ptr () -> Int -> Double -> Double -> Int -> Double -> Double -> IO ()
+#ccall cvHoughCircles, Ptr <CvArr> -> Ptr () -> Int -> Double -> Double -> Double -> Double -> Int -> Int -> IO ()
 
 #ccall wrapFilter2, Ptr  <CvArr> -> Ptr <CvArr> -> Ptr <CvMat> -> Ptr <CvPoint> -> IO ()
 

--- a/CV/HoughTransform.hs
+++ b/CV/HoughTransform.hs
@@ -89,3 +89,11 @@ houghLinesMultiscale img n ρ θ t distDiv angleDiv = unsafePerformIO $ do
         withImage img $ \c_img ->
             c'cvHoughLines2 (castPtr c_img) (castPtr c_m) c'CV_HOUGH_MULTI_SCALE ρ θ t distDiv angleDiv
     return $ toList m
+
+houghCirclesGradient :: Image GrayScale D8 -> Int -> Double -> Double -> Double -> Double -> Int -> Int -> [(CFloat, CFloat, CFloat)]
+houghCirclesGradient img n dp minDist cannyThresh accumThresh minRad maxRad = unsafePerformIO $ do
+    let m :: Matrix (CFloat,CFloat,CFloat) = create (1,n)
+    withMatPtr m $ \c_m ->
+        withImage img $ \c_img ->
+            c'cvHoughCircles (castPtr c_img) (castPtr c_m) c'CV_HOUGH_GRADIENT dp minDist cannyThresh accumThresh minRad maxRad
+    return $ toList m

--- a/CV/Matrix.hs
+++ b/CV/Matrix.hs
@@ -78,6 +78,10 @@ instance Exists (Matrix (Float,Float,Float)) where
     type Args (Matrix (Float,Float,Float)) = (Int,Int)
     create (r,c) = unsafePerformIO $ creatingMat (c'cvCreateMat r c c'CV_32FC3)
 
+instance Exists (Matrix (CFloat,CFloat,CFloat)) where
+    type Args (Matrix (CFloat,CFloat,CFloat)) = (Int,Int)
+    create (r,c) = unsafePerformIO $ creatingMat (c'cvCreateMat r c c'CV_32FC3)
+
 instance Exists (Matrix (Int,Int,Int,Int)) where
     type Args (Matrix (Int,Int,Int,Int)) = (Int,Int)
     create (r,c) = unsafePerformIO $ creatingMat (c'cvCreateMat r c c'CV_32SC4)
@@ -240,4 +244,3 @@ put (Matrix m) row col v = withForeignPtr m $ \mat -> do
 putRaw :: forall t. (Storable t) => Ptr t -> CInt -> Int -> Int -> Int -> t -> IO ()
 putRaw d step eltSize col row v =
          poke (castPtr (d `plusPtr` (col*(fromIntegral step)+row*eltSize))) v
-


### PR DESCRIPTION
Adds API for hough circles. Only tested on OpenCV 2.4, but I suspect it'd work for previous versions as well.
