### PR TITLE
Add CPP language directive to Transforms.chs

### DIFF
--- a/CV/Transforms.chs
+++ b/CV/Transforms.chs
@@ -1,4 +1,4 @@
-{-#LANGUAGE ForeignFunctionInterface, ViewPatterns, ScopedTypeVariables, PatternGuards, FlexibleContexts#-}
+{-#LANGUAGE CPP, ForeignFunctionInterface, ViewPatterns, ScopedTypeVariables, PatternGuards, FlexibleContexts#-}
 #include "cvWrapLEO.h"
 -- |Various image transformations from opencv and other sources.
 module CV.Transforms  where


### PR DESCRIPTION
To handle Transform.chs's OpenCV24 ifdefs
correctly, run it with CPP pre-processor
before compiling.
