### PR TITLE
Propose to fix issue #26

### DIFF
--- a/cbits/cvFiles.c
+++ b/cbits/cvFiles.c
@@ -1295,7 +1295,8 @@ IplImage *read_from_tcr_rectified_old(const char *path)
         unsigned int x, y, minx, maxx, miny, maxy, count;
         unsigned int new_width, new_height, startx, endx, starty, endy;
         float value, sum, sum1, sum2, min, max, ratio, stretch, avg, sdv;
-        float sum_count, min_count, stretch_1, stretch_2;
+        int sum_count, min_count;
+        float stretch_1, stretch_2;
 
         min = 2000000000;
         max = 0;


### PR DESCRIPTION
I think I fix issue #26 with assumption that xxx_count should be _int_ , please take a look.

``` diff
[wisut@wisut-pc CV]$ git diff origin/master 
diff --git a/cbits/cvFiles.c b/cbits/cvFiles.c
index 13314a3..3243f57 100644
--- a/cbits/cvFiles.c
+++ b/cbits/cvFiles.c
@@ -1295,7 +1295,8 @@ IplImage *read_from_tcr_rectified_old(const char *path)
         unsigned int x, y, minx, maxx, miny, maxy, count;
         unsigned int new_width, new_height, startx, endx, starty, endy;
         float value, sum, sum1, sum2, min, max, ratio, stretch, avg, sdv;
-        float sum_count, min_count, stretch_1, stretch_2;
+        int sum_count, min_count;
+        float stretch_1, stretch_2;

         min = 2000000000;
         max = 0;
```
