### PR TITLE
Fixed Image.getChannel not using the MutableImage with the relevant COI

### DIFF
--- a/CV/Image.chs
+++ b/CV/Image.chs
@@ -1010,7 +1010,7 @@ getChannel no image = unsafePerformIO $ creatingImage $ do
     mut <- toMutable image
     setCOI no mut
     cres <- {#call wrapCreateImage32F#} (fromIntegral w) (fromIntegral h) 1
-    withGenImage image $ \cimage ->
+    withMutableImage mut $ \cimage ->
       {#call cvCopy#} cimage (castPtr cres) (nullPtr)
     resetCOI mut
     return cres


### PR DESCRIPTION
I think I fixed a problem introcuced with the MutableImage type, which causes the following error in OpenCV when using the getChannel function:

```
OpenCV Error: Assertion failed (src.channels() == dst.channels()) in cvCopy, file /builddir/build/BUILD/opencv-2.4.5/modules/core/src/copy.cpp, line 575
terminate called after throwing an instance of 'cv::Exception'
  what():  /builddir/build/BUILD/opencv-2.4.5/modules/core/src/copy.cpp:575: error: (-215) src.channels() == dst.channels() in function cvCopy
```

I think the problem is that the actual copy is made from the original image instead of the MutableImage where the COI has been set. The proposed change fixes the problem in my application, and in the provided "examples/channels.hs".
