### PR TITLE
Fix build failure with lens-4.2

### DIFF
--- a/CV/Image.chs
+++ b/CV/Image.chs
@@ -350,8 +350,8 @@ instance Sized (MutableImage a b) where
     type Size (MutableImage a b) = IO (Int,Int)
    -- getSize :: (Integral a, Integral b) => Image c d -> (a,b)
     getSize (Mutable i) = evaluate (deep (getSize i))
-
-deep a = a `deepseq` a
+      where
+        deep a = a `deepseq` a
 
 instance Sized BareImage where
     type Size BareImage = (Int,Int)


### PR DESCRIPTION
Since lens-4.2 export the `deep`, turn CV.Image.deep into local function to avoid "ambiguous symbol" build error.